### PR TITLE
Move @vue/test-utils to dev dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,11 @@
       "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
-        "@vue/test-utils": "^2.0.0-rc.17",
         "vue": "^3.2.25"
       },
       "devDependencies": {
         "@vitejs/plugin-vue": "^2.2.0",
+        "@vue/test-utils": "^2.0.0-rc.17",
         "happy-dom": "^2.41.0",
         "jsdom": "^19.0.0",
         "vite": "^2.8.0",
@@ -220,6 +220,7 @@
       "version": "2.0.0-rc.17",
       "resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-2.0.0-rc.17.tgz",
       "integrity": "sha512-7LHZKsFRV/HqDoMVY+cJamFzgHgsrmQFalROHC5FMWrzPzd+utG5e11krj1tVsnxYufGA2ABShX4nlcHXED+zQ==",
+      "dev": true,
       "peerDependencies": {
         "vue": "^3.0.1"
       }
@@ -2144,6 +2145,7 @@
       "version": "2.0.0-rc.17",
       "resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-2.0.0-rc.17.tgz",
       "integrity": "sha512-7LHZKsFRV/HqDoMVY+cJamFzgHgsrmQFalROHC5FMWrzPzd+utG5e11krj1tVsnxYufGA2ABShX4nlcHXED+zQ==",
+      "dev": true,
       "requires": {}
     },
     "abab": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1769,9 +1769,9 @@
       "dev": true
     },
     "node_modules/vite": {
-      "version": "2.9.15",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.15.tgz",
-      "integrity": "sha512-fzMt2jK4vQ3yK56te3Kqpkaeq9DkcZfBbzHwYpobasvgYmP2SoAr6Aic05CsB4CzCZbsDv4sujX3pkEGhLabVQ==",
+      "version": "2.9.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.16.tgz",
+      "integrity": "sha512-X+6q8KPyeuBvTQV8AVSnKDvXoBMnTx8zxh54sOwmmuOdxkjMmEJXH2UEchA+vTMps1xw9vL64uwJOWryULg7nA==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.14.27",
@@ -3245,9 +3245,9 @@
       "dev": true
     },
     "vite": {
-      "version": "2.9.15",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.15.tgz",
-      "integrity": "sha512-fzMt2jK4vQ3yK56te3Kqpkaeq9DkcZfBbzHwYpobasvgYmP2SoAr6Aic05CsB4CzCZbsDv4sujX3pkEGhLabVQ==",
+      "version": "2.9.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.16.tgz",
+      "integrity": "sha512-X+6q8KPyeuBvTQV8AVSnKDvXoBMnTx8zxh54sOwmmuOdxkjMmEJXH2UEchA+vTMps1xw9vL64uwJOWryULg7nA==",
       "dev": true,
       "requires": {
         "esbuild": "^0.14.27",

--- a/package.json
+++ b/package.json
@@ -38,11 +38,11 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@vue/test-utils": "^2.0.0-rc.17",
     "vue": "^3.2.25"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^2.2.0",
+    "@vue/test-utils": "^2.0.0-rc.17",
     "happy-dom": "^2.41.0",
     "jsdom": "^19.0.0",
     "vite": "^2.8.0",


### PR DESCRIPTION
Moved @vue/test-utils to dev dependencies so the audit warning that popped up from that dependency doesn't propagate to project that do not need this dependency.